### PR TITLE
Fix typo in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 # top-most EditorConfig file
 root = true
 
-# 4 space indentation
+# 2 space indentation
 [*]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
I found a typo in `.editorconfig` commenting 4 space instead of 2 space

ref: https://cucumber.io/docs/gherkin/reference/#:~:text=The%20recommended%20indentation%20level%20is%20two%20spaces.